### PR TITLE
Add tests for couchDB 2.0

### DIFF
--- a/catalogv2.tests.bom
+++ b/catalogv2.tests.bom
@@ -1,0 +1,41 @@
+brooklyn.catalog:
+  items:
+  - https://raw.githubusercontent.com/brooklyncentral/common-catalog-utils/master/common-tests/src/main/resources/commontests/common.tests.bom
+  - id: couchdb2-node-tests
+    version: "1.0.0-SNAPSHOT"
+    itemType: template
+    name: Couchdb 2.0 node tests
+    description: Test that couchdb 2.0 node is running correctly
+    iconUrl: classpath:///couchdb-logo.png
+    item:
+      services:
+      - type: brooklyn-couchdb-node
+        id: parent-app
+        brooklyn.config:
+          install.version: 2.0.0
+
+      - type: test-case
+        brooklyn.config:
+          targetId: parent-app
+          targetResolutionTimeout: 10s
+          timeout: 30m
+
+        brooklyn.children:
+
+        - type: assert-up-and-running-initial
+          name: "1. Node up and running"
+
+        - type: assert-up-and-running-initial
+          name: "2. App up and running"
+          brooklyn.config:
+            targetId: parent-app
+
+        - type: assert-restart-process
+          name: "3. restart process"
+          brooklyn.config:
+            process.grep.name: "[c]ouchdb@localhost"
+
+        - type: assert-stop-and-restart-process
+          name: "4. stop and restart process"
+          brooklyn.config:
+            process.grep.name: "[c]ouchdb@localhost"


### PR DESCRIPTION
Note a change in the `process.grep.name` is required because of the erlang service path.